### PR TITLE
ci: remove redundant release please configuration in 1.106.1-patch branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,12 +1,3 @@
 bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
-branches:
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-lts
-    branch: 1.113.14-sp
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-yoshi
-    branch: 1.106.1-patch


### PR DESCRIPTION
Remove redundant release config to prevent release-please from submitting a PR every time a new commit comes into the main branch
